### PR TITLE
Fixes for production deploy

### DIFF
--- a/lib/torque/postgresql/railtie.rb
+++ b/lib/torque/postgresql/railtie.rb
@@ -3,11 +3,8 @@ module Torque
     # = Torque PostgreSQL Railtie
     class Railtie < Rails::Railtie # :nodoc:
 
-      # Eger load PostgreSQL namespace
-      config.eager_load_namespaces << Torque::PostgreSQL
-
       # Get information from the running rails app
-      runner do |app|
+      initializer 'torque-postgresql' do |app|
         Torque::PostgreSQL.config.eager_load = app.config.eager_load
       end
 


### PR DESCRIPTION
- Remove it form `eager_load_namespaces`
- Cache table_name/model on `reset_table_name`
- Ensure that the GEM runs on production mode