### PR TITLE
Avoid error with nil data sources

### DIFF
--- a/lib/torque/postgresql/schema_cache.rb
+++ b/lib/torque/postgresql/schema_cache.rb
@@ -145,7 +145,7 @@ module Torque
 
         # Generates the cache key for inheitance information
         def inheritance_cache_key
-          @data_sources.keys.sort.join(',')
+          @data_sources.keys.compact.sort.join(',')
         end
 
         # Reload information about tables inheritance and dependencies, uses a

--- a/lib/torque/postgresql/version.rb
+++ b/lib/torque/postgresql/version.rb
@@ -1,5 +1,5 @@
 module Torque
   module PostgreSQL
-    VERSION = '0.2.4'
+    VERSION = '0.2.5'
   end
 end


### PR DESCRIPTION
For some reason, there's a situation where the `@data_sources` on the Schema Cache gets a key-value pair of nil, breaking the sort.