### PR TITLE
Remove PG version lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rails', '~> 5.1.6'
-gem 'pg', '0.20'
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/lib/torque/postgresql/version.rb
+++ b/lib/torque/postgresql/version.rb
@@ -1,5 +1,5 @@
 module Torque
   module PostgreSQL
-    VERSION = '0.2.7'
+    VERSION = '0.3.0'
   end
 end

--- a/torque_postgresql.gemspec
+++ b/torque_postgresql.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.8.11'
 
   s.add_dependency 'rails', '>= 5.0', '< 5.2'
-  s.add_dependency 'pg', '>= 0.18'
+  s.add_dependency 'pg'
 
   s.add_development_dependency 'rake', '~> 10.1', '>= 10.1.0'
   s.add_development_dependency 'database_cleaner', '~> 1.5', '>= 1.5.3'


### PR DESCRIPTION
I'm a little unsure about how to specify the PG gem version here. 0.20 is quite behind by now though.