### PR TITLE
Create inherited tables only if any defined

### DIFF
--- a/lib/torque/postgresql/adapter/schema_dumper.rb
+++ b/lib/torque/postgresql/adapter/schema_dumper.rb
@@ -39,6 +39,8 @@ module Torque
 
           def tables(stream) # :nodoc:
             inherited_tables = @connection.inherited_tables
+            return super unless inherited_tables.present?
+            
             sorted_tables = @connection.data_sources.sort - @connection.views
 
             stream.puts "  # These are the common tables managed"


### PR DESCRIPTION
This is a quick PR that simply fences off creation of inherited tables in case there are none defined.

The underlying issue is that this gem, by re-processing the table schema, removes the raw SQL view definitions added by the [Scenic](https://github.com/scenic-views/scenic) gem. This PR makes torque-postgresql work with Scenic if you are not using the inherited tables functionality.

These look like this:
```ruby
create_view "my_view_name", sql_definition: <<-SQL
  …
SQL
```

@crashtech perhaps you know how to let these definitions go through the `tables` method on Torque's `SchemaDumper`?