### PR TITLE
Update Builder to support views as well

### DIFF
--- a/lib/torque/postgresql/attributes/builder.rb
+++ b/lib/torque/postgresql/attributes/builder.rb
@@ -9,7 +9,8 @@ module Torque
       module Builder
         def self.include_on(klass, method_name, builder_klass, **extra, &block)
           klass.define_singleton_method(method_name) do |*args, **options|
-            return unless connection.table_exists?(table_name)
+            return unless connection.table_exists?(table_name) ||
+                          connection.view_exists?(table_name)
 
             args.each do |attribute|
               begin

--- a/lib/torque/postgresql/attributes/builder.rb
+++ b/lib/torque/postgresql/attributes/builder.rb
@@ -9,8 +9,7 @@ module Torque
       module Builder
         def self.include_on(klass, method_name, builder_klass, **extra, &block)
           klass.define_singleton_method(method_name) do |*args, **options|
-            return unless connection.table_exists?(table_name) ||
-                          connection.view_exists?(table_name)
+            return unless table_exists?
 
             args.each do |attribute|
               begin


### PR DESCRIPTION
Recently I wanted to use the Range attribute on a PostgreSQL view, and found out the Builder only applies to classes backed by a table. This PR permits views as well.