### PR TITLE
Update :has_many association to support UUIDs

### DIFF
--- a/lib/torque/postgresql/reflection/abstract_reflection.rb
+++ b/lib/torque/postgresql/reflection/abstract_reflection.rb
@@ -6,6 +6,9 @@ module Torque
       module AbstractReflection
         AREL_ATTR = ::Arel::Attributes::Attribute
 
+        ARR_NO_CAST = 'bigint'
+        ARR_CAST = 'bigint[]'
+
         # Check if the foreign key actually exists
         def connected_through_array?
           false
@@ -55,7 +58,9 @@ module Torque
           return klass_attr.in(source_attr) unless klass_type.try(:array)
 
           # Decide if should apply a cast to ensure same type comparision
-          should_cast = !klass_type.sql_type.eql?(source_type.sql_type)
+          should_cast = klass_type.type.eql?(:integer) && source_type.type.eql?(:integer)
+          should_cast &= !klass_type.sql_type.eql?(source_type.sql_type)
+          should_cast |= !(klass_attr.is_a?(AREL_ATTR) && source_attr.is_a?(AREL_ATTR))
 
           # Apply necessary transformations to values
           klass_attr = cast_constraint_to_array(klass_type, klass_attr, should_cast)
@@ -84,10 +89,10 @@ module Torque
           # Prepare a value for an array constraint overlap condition
           def cast_constraint_to_array(type, value, should_cast)
             base_ready = type.try(:array) && value.is_a?(AREL_ATTR)
-            return value if base_ready && !should_cast
+            return value if base_ready && (type.sql_type.eql?(ARR_NO_CAST) || !should_cast)
 
             value = ::Arel::Nodes.build_quoted(Array.wrap(value)) unless base_ready
-            value = value.cast("#{type.sql_type}[]") if should_cast
+            value = value.cast(ARR_CAST) if should_cast
             value
           end
 

--- a/torque_postgresql.gemspec
+++ b/torque_postgresql.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.5', '>= 3.5.0'
 
   s.add_development_dependency 'factory_bot', '~> 5.0', '>= 5.0.2'
-  s.add_development_dependency 'faker', '~> 1.5', '>= 1.5.0'
+  s.add_development_dependency 'faker', '~> 2.0'
 end


### PR DESCRIPTION
At the moment, the `has_many` association support only for columns of `integer` type.

This PR adds support for `uuid`.

Few notes:
* It might be good to abstract this further – without the need for `ARR_NO_CAST` & `ARR_CAST` constants.
* This PR fails on Ruby 3 (unrelated to changes in this PR, the `master` branch does fail on Ruby 3 as well). If you'd like me to rebase to `v2.2.2` so that everything passes please let me know. Thanks!