### PR TITLE
Rails 7 & Ruby 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.5.8
-  - 2.6.6
   - 2.7.2
   - 3.0.1
+  - 3.1.0
 
 gemfile:
   - gemfiles/Gemfile.rails-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 gemfile:
   - gemfiles/Gemfile.rails-6.0
   - gemfiles/Gemfile.rails-6.1
+  - gemfiles/Gemfile.rails-7.0
 
 cache:
   bundler: true

--- a/gemfiles/Gemfile.rails-7.0
+++ b/gemfiles/Gemfile.rails-7.0
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.0'
+gem 'pg', '~> 1.2.3'
+gem "byebug"
+
+gemspec path: "../"

--- a/torque_postgresql.gemspec
+++ b/torque_postgresql.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files      = Dir['MIT-LICENSE', 'README.rdoc', 'lib/**/*', 'Rakefile']
   s.test_files = Dir['spec/**/*']
 
-  s.required_ruby_version     = '>= 2.5.0'
+  s.required_ruby_version     = '>= 2.7.2'
   s.required_rubygems_version = '>= 1.8.11'
 
   s.add_dependency 'rails', '>= 6.0'


### PR DESCRIPTION
This PR:
* runs tests on Rails 7 as well
* runs tests on Ruby 3.1
* removes support for Ruby < 2.7.2