### PR TITLE
Ensure queries virtual attributes do not cause a crash

### DIFF
--- a/lib/torque/postgresql/associations/preloader/loader_query.rb
+++ b/lib/torque/postgresql/associations/preloader/loader_query.rb
@@ -24,7 +24,7 @@ module Torque
           end
 
           def connected_through_array?
-            !association_key_name.is_a?(Array) && foreign_column.array?
+            !association_key_name.is_a?(Array) && foreign_column&.array?
           end
         end
 


### PR DESCRIPTION
`has_many` with scoped declaring virtual attributes are rightfully not present in the `columns_hash`.
This causes the `connected_through_array?` to crash.

Setup to replicate the issue
```rb
# models/company.rb
has_many :companies_users
has_many :users, through: :companies_users

# models/companies_user.rb
belongs_to :user
belongs_to :company

# models/event.rb
has_many :companies, -> { polymorphic_company_scope }, primary_key: 'user_account_id', foreign_key: 'virtual_user_account_id' 

def self.polymorphic_company_scope
    companies_q = <<-SQL.squish
        SELECT
            companies.*,
            companies_users.user_id AS v_user_account_id
        FROM
            companies
            INNER JOIN companies_users ON companies.id = companies_users.company_id
    SQL

    -> { from("(#{ActiveRecord::Base.connection.quote_string(companies_q)}) companies") }
end
```

The virtual attribute `virtual_user_account_id` will cause the crash