### PR TITLE
abstract_reflection: don't use OpenStruct

### DIFF
--- a/lib/torque/postgresql/reflection/abstract_reflection.rb
+++ b/lib/torque/postgresql/reflection/abstract_reflection.rb
@@ -67,7 +67,7 @@ module Torque
 
         # TODO: Deprecate this method
         def join_keys
-          OpenStruct.new(key: join_primary_key, foreign_key: join_foreign_key)
+          KeyAndForeignKey.new(key: join_primary_key, foreign_key: join_foreign_key)
         end
 
         private
@@ -79,6 +79,8 @@ module Torque
             build_id_constraint(klass_attr, source_attr)
           end
       end
+
+      KeyAndForeignKey = Struct.new(:key, :foreign_key, keyword_init: true)
 
       ::ActiveRecord::Reflection::AbstractReflection.prepend(AbstractReflection)
     end


### PR DESCRIPTION
OpenStruct is not recommended for performance reasons, when running ruby with `-W:performance`, we get lots of:
`/Users/XXX/.rvm/gems/ruby-3.3.4/gems/torque-postgresql-3.4.0/lib/torque/postgresql/reflection/abstract_reflection.rb:70: warning: OpenStruct use is discouraged for performance reasons`

Moving this code to Struct solves this issue.